### PR TITLE
simple bugfixes

### DIFF
--- a/classes/parser/convert/converterhelper.cpp
+++ b/classes/parser/convert/converterhelper.cpp
@@ -510,11 +510,13 @@ void ConverterHelper::createImagePreview(Settings::Presets::Preset *preset, QIma
       }
 
       // apply mask
-      for (int x = 0; x < im.width(); x++) {
-        for (int y = 0; y < im.height(); y++) {
-          QRgb value = im.pixel(x, y);
-          value &= mask;
-          im.setPixel(x, y, value);
+      if (mask != 0xffffffff) {
+        for (int x = 0; x < im.width(); x++) {
+          for (int y = 0; y < im.height(); y++) {
+            QRgb value = im.pixel(x, y);
+            value &= mask;
+            im.setPixel(x, y, value);
+          }
         }
       }
     }

--- a/controls/setup/dialogoptions.cpp
+++ b/controls/setup/dialogoptions.cpp
@@ -331,7 +331,7 @@ void DialogOptions::on_comboBoxPresets_currentIndexChanged(int index)
 void DialogOptions::previewClosed()
 {
   if (this->mPreview != nullptr) {
-    delete this->mPreview;
+    this->mPreview->deleteLater();
     this->mPreview = nullptr;
   }
 }


### PR DESCRIPTION
1. Workaround complaints from monochrome QImage that won't allow pixel manipulations.

If no mask is used we can skip this step.
note: The bug remains, that monochrome images cannot be masked.

2. Crash on preview dialog close

Because the QObject was delete while the event handler is active the application crashed for me in debug mode.
Using `deleteLater()` is always the safe option for QObjects.