### PR TITLE
Add PainterPath includes such that this project builds using clang

### DIFF
--- a/classes/imageeditor/toolfill.cpp
+++ b/classes/imageeditor/toolfill.cpp
@@ -19,6 +19,7 @@
 
 #include "toolfill.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>

--- a/classes/imageeditor/toolline.cpp
+++ b/classes/imageeditor/toolline.cpp
@@ -19,6 +19,7 @@
 
 #include "toolline.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>

--- a/classes/imageeditor/toolpen.cpp
+++ b/classes/imageeditor/toolpen.cpp
@@ -27,6 +27,7 @@
 #include <QMouseEvent>
 #include <QToolButton>
 #include <QColorDialog>
+#include <QPainterPath>
 #include <appsettings.h>
 #include "bitmaphelper.h"
 #include "iimageeditorparams.h"

--- a/classes/imageeditor/toolrect.cpp
+++ b/classes/imageeditor/toolrect.cpp
@@ -19,6 +19,7 @@
 
 #include "toolrect.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>


### PR DESCRIPTION
When building this project with clang, it complains about the PainterPath.h not being included.