### PR TITLE
Fix compilation error with Qt 5.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build/
+release/
+.qmake.stash
 _linux/
 _windows/
 .moc/

--- a/classes/imageeditor/toolfill.cpp
+++ b/classes/imageeditor/toolfill.cpp
@@ -19,6 +19,7 @@
 
 #include "toolfill.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>

--- a/classes/imageeditor/toolline.cpp
+++ b/classes/imageeditor/toolline.cpp
@@ -19,6 +19,7 @@
 
 #include "toolline.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>

--- a/classes/imageeditor/toolpen.cpp
+++ b/classes/imageeditor/toolpen.cpp
@@ -19,6 +19,7 @@
 
 #include "toolpen.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>

--- a/classes/imageeditor/toolrect.cpp
+++ b/classes/imageeditor/toolrect.cpp
@@ -19,6 +19,7 @@
 
 #include "toolrect.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QList>
 #include <QAction>
 #include <QWidget>


### PR DESCRIPTION
This fixes the build errors that occur when building with Qt 5.15 (and maybe others).

```
classes/imageeditor/toolfill.cpp:194:43: error: member access into incomplete type 'const QPainterPath'
  194 |     if (!this->mParameters->selectedPath().isEmpty()) {
      |                                           ^
/opt/homebrew/Cellar/qt@5/5.15.16/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
   54 | class QPainterPath;
      |       ^
1 error generated.
make: *** [release/linux/.obj/toolfill.o] Error 1
```